### PR TITLE
send --to: reach a person's existing 1:1 DM by email or users/<id>

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,7 +76,7 @@ Placing it in the core, not in a wrapper, means any front door (and any future f
 
 ## Sending
 
-`send` posts a message to a space, or a reply into a thread, through both front doors, always over the direct Chat API (a write has no cache path). The write side follows the same discipline as the reads:
+`send` posts a message to a space, a reply into a thread, or a message into a person's existing 1:1 DM (`--to`, an email or `users/<id>`, resolved by the API's find-direct-message call). It works through both front doors, always over the direct Chat API (a write has no cache path). The write side follows the same discipline as the reads:
 
 - The sieve applies to writes: a send into a blocked space is refused with the same wording as a space that does not exist, so a caller cannot probe the block list through send.
 - A set `WORLD_AS_OF` refuses the send outright: a bounded run is a replay, and a send would act in the real present.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ majordomo messages --space spaces/AAAA --window 7d
 majordomo messages --thread spaces/AAAA/messages/BBBB
 majordomo send --space spaces/AAAA "On my way."
 majordomo send --thread spaces/AAAA/messages/BBBB "Done, see the doc."
+majordomo send --to alice@example.com "Lunch?"       # a person's existing 1:1 DM
 majordomo mcp                       # run the MCP server (stdio)
 ```
 

--- a/src/majordomo/_claude_command.py
+++ b/src/majordomo/_claude_command.py
@@ -29,7 +29,7 @@ COMMAND_NAME = "majordomo"
 # not the description.
 COMMAND = """---
 name: majordomo
-description: Who holds which Google Chat tasks: tasks assigned by or to a person, plus message and task counts per space or person, over any date range. Covers Chat-created tasks the Tasks API cannot return. Also sends a Google Chat message to a space, or a reply into a thread.
+description: Who holds which Google Chat tasks: tasks assigned by or to a person, plus message and task counts per space or person, over any date range. Covers Chat-created tasks the Tasks API cannot return. Also sends a Google Chat message to a space, a thread, or a person's DM (by email).
 allowed-tools: Bash
 ---
 
@@ -73,9 +73,10 @@ Raw messages in one space, or one thread (any message resource name in the threa
 ```bash
 majordomo send --space spaces/AAAA "On my way."
 majordomo send --thread spaces/AAAA/messages/BBBB "Done, see the doc."
+majordomo send --to alice@example.com "Lunch?"
 ```
 
-One target: `--space` posts to the space, `--thread` replies in a thread (any message resource name in it works). Sends as the logged-in account; a token from before send existed lacks the scope, and the error says to re-run `majordomo login`. A blocked space answers "not found". While `WORLD_AS_OF` is set, a send is refused: a bounded run is a replay.
+One target: `--space` posts to the space, `--thread` replies in a thread (any message resource name in it works), `--to` reaches a person's existing 1:1 DM by email or `users/<id>` (a person you have never DM'd is refused; majordomo does not open new DMs). Sends as the logged-in account; a token from before send existed lacks the scope, and the error says to re-run `majordomo login`. A blocked space answers "not found". While `WORLD_AS_OF` is set, a send is refused: a bounded run is a replay.
 
 ## Windows, output, source
 

--- a/src/majordomo/api.py
+++ b/src/majordomo/api.py
@@ -129,30 +129,51 @@ def _thread_target(thread: str) -> tuple[str, str]:
     return "/".join(key.split("/")[:2]), key.replace("/messages/", "/threads/")
 
 
+def _dm_space(service, blocked: list[str], to: str) -> str:
+    """The existing 1:1 direct-message space with a person, or a clean refusal.
+
+    ``to`` is users/<id>, a bare id, or an email (the API takes the email as
+    an alias for the id). A DM the sieve blocks answers exactly like one that
+    does not exist, so the resolved space id stays unspoken.
+    """
+    user = to if to.startswith("users/") else f"users/{to}"
+    absent = f"majordomo: no direct message space with {user}."
+    try:
+        found = service.spaces().findDirectMessage(name=user).execute()
+    except Exception as exc:
+        if getattr(getattr(exc, "resp", None), "status", None) == 404:
+            raise SystemExit(absent) from None
+        raise
+    space = found.get("name")
+    if not sieve.allows(blocked, space):
+        raise SystemExit(absent)
+    return space
+
+
 def send(cfg: dict, blocked: list[str], *, space: str | None = None,
-         thread: str | None = None, text: str, service=None) -> dict:
-    """Create a message in a space, or reply in a thread; returns the created
-    message as the API gives it. The sieve refuses a blocked space with the
-    same wording as a space that does not exist, so send cannot probe the
-    block list. Refuses under WORLD_AS_OF: a bounded run is a replay, and a
-    send would act in the real present.
+         thread: str | None = None, to: str | None = None, text: str,
+         service=None) -> dict:
+    """Create a message in a space, in a thread, or in a person's 1:1 DM;
+    returns the created message as the API gives it. The sieve refuses a
+    blocked space with the same wording as a space that does not exist, so
+    send cannot probe the block list. Refuses under WORLD_AS_OF: a bounded
+    run is a replay, and a send would act in the real present.
     """
     if config.world_as_of() is not None:
         raise SystemExit(
             "majordomo: WORLD_AS_OF is set (a replay bound); refusing to send "
             "a real message from a bounded run."
         )
-    if (space is None) == (thread is None):
-        raise SystemExit("majordomo: send needs exactly one of space / thread.")
+    if (space, thread, to).count(None) != 2:
+        raise SystemExit("majordomo: send needs exactly one of space / thread / to.")
     body: dict = {"text": text}
     kwargs: dict = {}
     if thread:
         space, thread_name = _thread_target(thread)
         body["thread"] = {"name": thread_name}
         kwargs["messageReplyOption"] = "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"
-    not_found = f"majordomo: {space}: not found."
-    if not sieve.allows(blocked, space):
-        raise SystemExit(not_found)
+    if space and not sieve.allows(blocked, space):
+        raise SystemExit(f"majordomo: {space}: not found.")
     if service is None:
         creds = get_credentials(cfg)
         if SEND_SCOPE not in (creds.scopes or []):
@@ -162,12 +183,14 @@ def send(cfg: dict, blocked: list[str], *, space: str | None = None,
             )
         _, _, build = _require_google()
         service = build("chat", "v1", credentials=creds, cache_discovery=False)
+    if to:
+        space = _dm_space(service, blocked, to)
     try:
         return service.spaces().messages().create(parent=space, body=body, **kwargs).execute()
     except Exception as exc:
         # A 404 answers exactly like the sieve above, one wording for both.
         if getattr(getattr(exc, "resp", None), "status", None) == 404:
-            raise SystemExit(not_found) from None
+            raise SystemExit(f"majordomo: {space}: not found.") from None
         raise
 
 

--- a/src/majordomo/cli.py
+++ b/src/majordomo/cli.py
@@ -171,19 +171,20 @@ def send(
     text: str = typer.Argument(..., help="Message text."),
     space: Optional[str] = typer.Option(None, "--space", help="Space resource name (spaces/<id>)."),
     thread: Optional[str] = typer.Option(None, "--thread", help="Reply in this thread (or any message name in it)."),
+    to: Optional[str] = typer.Option(None, "--to", help="Person's existing 1:1 DM: an email or users/<id>."),
     json_out: bool = typer.Option(False, "--json", help="Raw JSON of the created message."),
 ) -> None:
-    """Send a message to a space, or reply in a thread (needs the `api` extra).
+    """Send a message to a space, a thread, or a person's DM (needs the `api` extra).
 
     Refused while WORLD_AS_OF is set: a bounded run is a replay, and a send
     would act in the real present.
     """
-    if (space is None) == (thread is None):
-        typer.echo("majordomo: send needs exactly one of --space / --thread.", err=True)
+    if (space, thread, to).count(None) != 2:
+        typer.echo("majordomo: send needs exactly one of --space / --thread / --to.", err=True)
         raise typer.Exit(2)
     from . import api
     cfg = config.load_config()
-    created = api.send(cfg, config.block_spaces(cfg), space=space, thread=thread, text=text)
+    created = api.send(cfg, config.block_spaces(cfg), space=space, thread=thread, to=to, text=text)
     if json_out:
         typer.echo(json.dumps(created, indent=2, default=str))
     else:

--- a/src/majordomo/cli.py
+++ b/src/majordomo/cli.py
@@ -171,10 +171,13 @@ def send(
     text: str = typer.Argument(..., help="Message text."),
     space: Optional[str] = typer.Option(None, "--space", help="Space resource name (spaces/<id>)."),
     thread: Optional[str] = typer.Option(None, "--thread", help="Reply in this thread (or any message name in it)."),
-    to: Optional[str] = typer.Option(None, "--to", help="Person's existing 1:1 DM: an email or users/<id>."),
+    to: Optional[str] = typer.Option(None, "--to", help="A person, by email or users/<id>: sends in your 1:1 DM, and says so if you have none with them."),
     json_out: bool = typer.Option(False, "--json", help="Raw JSON of the created message."),
 ) -> None:
-    """Send a message to a space, a thread, or a person's DM (needs the `api` extra).
+    """Send a Google Chat message to a space, a thread, or a person (needs the `api` extra).
+
+    An email address in --to names the person, not an email channel: the
+    message arrives in your 1:1 Chat DM with them.
 
     Refused while WORLD_AS_OF is set: a bounded run is a replay, and a send
     would act in the real present.

--- a/src/majordomo/mcp_server.py
+++ b/src/majordomo/mcp_server.py
@@ -126,15 +126,17 @@ def create_server() -> FastMCP:
         return _envelope(reader, reader.messages(space, thread=thread, start=start, end=end, limit=limit))
 
     @server.tool()
-    def send(text: str, space: Optional[str] = None, thread: Optional[str] = None) -> dict:
-        """Send a message to a space, or reply in a thread (thread takes a thread
-        or any message name in it). Exactly one of space/thread. The sieve
-        refuses blocked spaces; a set WORLD_AS_OF refuses the send outright,
-        a bounded run being a replay.
+    def send(text: str, space: Optional[str] = None, thread: Optional[str] = None,
+             to: Optional[str] = None) -> dict:
+        """Send a message to a space, a thread, or a person's existing 1:1 DM.
+        Exactly one of space/thread/to: thread takes a thread or any message
+        name in it; to takes an email or users/<id>. The sieve refuses blocked
+        spaces; a set WORLD_AS_OF refuses the send outright, a bounded run
+        being a replay.
         """
         cfg = _config()
         try:
-            return api.send(cfg, config.block_spaces(cfg), space=space, thread=thread, text=text)
+            return api.send(cfg, config.block_spaces(cfg), space=space, thread=thread, to=to, text=text)
         except SystemExit as exc:
             # Core refusals arrive as SystemExit; they answer this tool call,
             # they do not end the server process.

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -25,6 +25,25 @@ def _create_kwargs(chat):
     return kwargs
 
 
+def _chat_with_dm(user_to_space, created=None):
+    """A fake whose findDirectMessage knows the given users/<x> -> space map
+    and answers 404 for anyone else, like the API."""
+    chat = _chat(created)
+
+    def find_dm(name=None):
+        page = MagicMock()
+        if name in user_to_space:
+            page.execute.return_value = {"name": user_to_space[name], "spaceType": "DIRECT_MESSAGE"}
+        else:
+            err = Exception("404")
+            err.resp = types.SimpleNamespace(status=404)
+            page.execute.side_effect = err
+        return page
+
+    chat.spaces().findDirectMessage.side_effect = find_dm
+    return chat
+
+
 def test_send_to_space_calls_create():
     chat = _chat({"name": "spaces/OK/messages/NEW"})
     out = api.send({}, [], space="spaces/OK", text="hi", service=chat)
@@ -103,11 +122,44 @@ def test_token_without_send_scope_points_at_login(monkeypatch):
     assert "majordomo login" in str(ei.value)
 
 
+def test_to_email_resolves_the_dm_and_sends():
+    chat = _chat_with_dm({"users/alice@example.com": "spaces/DM1"})
+    api.send({}, [], to="alice@example.com", text="hi", service=chat)
+    kwargs = _create_kwargs(chat)
+    assert kwargs["parent"] == "spaces/DM1"
+    assert kwargs["body"] == {"text": "hi"}
+
+
+def test_to_accepts_the_users_id_form():
+    chat = _chat_with_dm({"users/123": "spaces/DM2"})
+    api.send({}, [], to="users/123", text="hi", service=chat)
+    assert _create_kwargs(chat)["parent"] == "spaces/DM2"
+
+
+def test_to_without_an_existing_dm_refused_cleanly():
+    chat = _chat_with_dm({})
+    with pytest.raises(SystemExit) as ei:
+        api.send({}, [], to="bob@example.com", text="hi", service=chat)
+    assert str(ei.value) == "majordomo: no direct message space with users/bob@example.com."
+    chat.spaces().messages().create.assert_not_called()
+
+
+def test_to_blocked_dm_answers_like_an_absent_one():
+    chat = _chat_with_dm({"users/alice@example.com": "spaces/BLOCKDM"})
+    with pytest.raises(SystemExit) as ei:
+        api.send({}, ["spaces/BLOCKDM"], to="alice@example.com", text="hi", service=chat)
+    assert str(ei.value) == "majordomo: no direct message space with users/alice@example.com."
+    chat.spaces().messages().create.assert_not_called()
+
+
 def test_needs_exactly_one_target():
     with pytest.raises(SystemExit):
         api.send({}, [], text="hi", service=_chat())
     with pytest.raises(SystemExit):
         api.send({}, [], space="spaces/OK", thread="spaces/OK/threads/T",
+                 text="hi", service=_chat())
+    with pytest.raises(SystemExit):
+        api.send({}, [], space="spaces/OK", to="alice@example.com",
                  text="hi", service=_chat())
 
 


### PR DESCRIPTION
Stacked on #5 (the tested 0.1.5), which stays frozen; GitHub retargets this to main when #5 merges.

`majordomo send --to alice@example.com "text"` (or `--to users/<id>`) resolves the person's existing 1:1 DM with one findDirectMessage call and sends there; the MCP tool takes the same parameter. The email alias for the id was verified against the live API with the existing read scope: the lookup returned the same DM space a field test had found by scanning 46 spaces by hand.

Boundaries and rules:
- Existing DMs only. A person with no 1:1 DM yet is refused with a clean line; opening a DM is another write scope and a separate decision.
- A DM the sieve blocks answers exactly like one that does not exist, so the resolved space id stays unspoken.
- No new consent: the lookup runs on the read scope; sending itself still needs the post-0.1.5 token from `majordomo login`.

Verification: 97 tests pass (4 new: email form, users/<id> form, absent-DM refusal, blocked-DM wording). No real message was transmitted.

Intended release: 0.1.6, after 0.1.5 ships; the version stays 0.1.5 here on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)